### PR TITLE
Update the documentation according to recent fix: use `<picture>` instead of `<figure>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ resizes the image to support multiple view port sizes and renderes the appropria
 
 ```html
 <p class="md__image">
-<figure>
+<picture>
   <source media="(min-width:500px)" srcset="/.../image/map_500x0_resize_q75_box.jpg">
   <source media="(min-width:800px)" srcset="/.../image/map_800x0_resize_q75_box.jpg">
   <source media="(min-width:1200px)" srcset="/.../image/map_1200x0_resize_q75_box.jpg">
   <source media="(min-width:1500px)" srcset="/.../image/map_1500x0_resize_q75_box.jpg">
   <img src="image/map.jpg" alt="a map of the universe" title="a map of the universe" style="width:auto;">
   <figcaption>I wonder where I have to go</figcaption>
-</figure>
+</picture>
 </p>
 ```
 


### PR DESCRIPTION

Ref: https://github.com/jan-xyz/hugo-module-img-srcset/commit/6e0ddb2db6e29764007900751270414ff2d07c98